### PR TITLE
setup chrome jest; add upsert chrome storage method; wire upsert button

### DIFF
--- a/__tests__/__mocks__/chrome.ts
+++ b/__tests__/__mocks__/chrome.ts
@@ -1,0 +1,8 @@
+export const chrome = {
+    storage: {
+        local: {
+            get: jest.fn(),
+            set: jest.fn().mockResolvedValue(undefined),
+        },
+    },
+};

--- a/__tests__/chromeStorageRiffsRepository.test.ts
+++ b/__tests__/chromeStorageRiffsRepository.test.ts
@@ -1,0 +1,138 @@
+import { ChromeStorageRiffsRepository } from "../src/riffsRepository/chromeStorageRiffsRepository";
+import { Riff } from "../src/types";
+import { RiffsRepositroy } from "../src/riffsRepository/riffsRepository";
+import { chrome } from "jest-chrome";
+
+describe("ChromeStorageRiffsRepository", () => {
+    const mockChromeGet = jest.fn();
+    chrome.storage.local.get = mockChromeGet;
+
+    let repository: RiffsRepositroy;
+    const videoId = "test-video-id";
+    const sampleRiff: Riff = {
+        hotkey: "a",
+        name: "Sample riff text",
+        time: 15,
+    };
+
+    beforeEach(() => {
+        repository = new ChromeStorageRiffsRepository();
+        jest.clearAllMocks();
+    });
+
+    describe("getRiffs", () => {
+        it("should return empty array when no riffs exist", async () => {
+            mockChromeGet.mockResolvedValue({});
+            const result = await repository.getRiffs(videoId);
+            expect(mockChromeGet).toHaveBeenCalledWith(`riffs_${videoId}`);
+            expect(result).toEqual([]);
+        });
+
+        it("should return riffs when they exist", async () => {
+            const existingRiffs = [sampleRiff];
+            mockChromeGet.mockResolvedValue({
+                [`riffs_${videoId}`]: existingRiffs,
+            });
+
+            const result = await repository.getRiffs(videoId);
+
+            expect(mockChromeGet).toHaveBeenCalledWith(`riffs_${videoId}`);
+            expect(result).toEqual(existingRiffs);
+        });
+    });
+
+    describe("addRiff", () => {
+        it("should add a riff to an empty array", async () => {
+            mockChromeGet.mockResolvedValue({});
+
+            await repository.addRiff(videoId, sampleRiff);
+
+            expect(mockChromeGet).toHaveBeenCalledWith(`riffs_${videoId}`);
+            expect(chrome.storage.local.set).toHaveBeenCalledWith({
+                [`riffs_${videoId}`]: [sampleRiff],
+            });
+        });
+
+        it("should add a riff to existing riffs", async () => {
+            const existingRiff = {
+                hotkey: "b",
+                text: "Existing riff",
+                timestamp: 10,
+            };
+
+            mockChromeGet.mockResolvedValue({
+                [`riffs_${videoId}`]: [existingRiff],
+            });
+
+            await repository.addRiff(videoId, sampleRiff);
+
+            expect(mockChromeGet).toHaveBeenCalledWith(`riffs_${videoId}`);
+            expect(chrome.storage.local.set).toHaveBeenCalledWith({
+                [`riffs_${videoId}`]: [existingRiff, sampleRiff],
+            });
+        });
+    });
+
+    describe("deleteRiff", () => {
+        it("should remove a riff based on hotkey", async () => {
+            const existingRiffs = [
+                sampleRiff,
+                { hotkey: "b", text: "Another riff", timestamp: 20 },
+            ];
+            mockChromeGet.mockResolvedValue({
+                [`riffs_${videoId}`]: existingRiffs,
+            });
+
+            await repository.deleteRiff(videoId, sampleRiff);
+
+            expect(chrome.storage.local.set).toHaveBeenCalledWith({
+                [`riffs_${videoId}`]: [
+                    { hotkey: "b", text: "Another riff", timestamp: 20 },
+                ],
+            });
+        });
+
+        it("should not change anything if riff doesn't exist", async () => {
+            const existingRiffs = [
+                { hotkey: "b", text: "Another riff", timestamp: 20 },
+            ];
+            mockChromeGet.mockResolvedValue({
+                [`riffs_${videoId}`]: existingRiffs,
+            });
+
+            await repository.deleteRiff(videoId, sampleRiff);
+
+            expect(chrome.storage.local.set).toHaveBeenCalledWith({
+                [`riffs_${videoId}`]: existingRiffs,
+            });
+        });
+    });
+
+    describe("upsertRiff", () => {
+        it("should add a new riff if hotkey doesn't exist", async () => {
+            mockChromeGet.mockResolvedValue({});
+
+            await repository.upsertRiff(videoId, sampleRiff);
+
+            expect(chrome.storage.local.set).toHaveBeenCalledWith({
+                [`riffs_${videoId}`]: [sampleRiff],
+            });
+        });
+
+        it("should update an existing riff with the same hotkey", async () => {
+            const existingRiffs = [
+                { hotkey: "a", text: "Old text", timestamp: 5 },
+            ];
+            mockChromeGet.mockResolvedValue({
+                [`riffs_${videoId}`]: existingRiffs,
+            });
+
+            const updatedRiff = { ...sampleRiff, text: "Updated text" };
+            await repository.upsertRiff(videoId, updatedRiff);
+
+            expect(chrome.storage.local.set).toHaveBeenCalledWith({
+                [`riffs_${videoId}`]: [updatedRiff],
+            });
+        });
+    });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,4 +22,5 @@ export default {
     },
     extensionsToTreatAsEsm: [".ts", ".tsx"],
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+    setupFilesAfterEnv: ["./jest.setup.js"],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+Object.assign(global, require("jest-chrome"));

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "csstype": "^3.1.3",
         "http-server": "^14.1.1",
         "jest": "^29.7.0",
+        "jest-chrome": "^0.8.0",
         "jest-environment-jsdom": "^29.7.0",
         "style-loader": "^4.0.0",
         "ts-jest": "^29.3.1",

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -59,7 +59,7 @@ const $riffsContainer = css({
 interface ControlPanelProps {
     videoId?: string;
     riffs: Record<string, Riff>;
-    onAddRiff: (riff: Riff, videoId?: string) => Promise<void>;
+    onSubmitRiff: (riff: Riff, videoId?: string) => Promise<void>;
     onDeleteRiff: (riff: Riff, videoId?: string) => Promise<void>;
 }
 
@@ -68,7 +68,7 @@ export const ControlPanel = (props: ControlPanelProps) => {
         RiffDialogValues | undefined
     >(undefined);
 
-    const { onAddRiff, onDeleteRiff, riffs, videoId } = props;
+    const { onSubmitRiff, onDeleteRiff, riffs, videoId } = props;
 
     const handleAddRiff = () => {
         const newRiff: RiffDialogValues = {
@@ -86,7 +86,7 @@ export const ControlPanel = (props: ControlPanelProps) => {
     };
 
     const handleSubmitRiff = async (riff: Riff) => {
-        await onAddRiff(riff, videoId);
+        await onSubmitRiff(riff, videoId);
         setSelectedRiff(undefined);
     };
 

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -28,10 +28,10 @@ const loadRiffs = async (videoId: string) => {
     }
 };
 
-const handleAddRiff = async (riff: Riff, videoId?: string) => {
+const handleSubmitRiff = async (riff: Riff, videoId?: string) => {
     riffs[riff.hotkey] = riff;
     if (videoId) {
-        await riffsRepository.addRiff(videoId, riff);
+        await riffsRepository.upsertRiff(videoId, riff);
     }
     renderControlPanel(videoId);
 };
@@ -59,7 +59,7 @@ const renderControlPanel = (videoId: string | undefined) => {
         <ControlPanel
             videoId={videoId}
             riffs={riffs}
-            onAddRiff={handleAddRiff}
+            onSubmitRiff={handleSubmitRiff}
             onDeleteRiff={handleDeleteRiff}
         />,
         rootContainer

--- a/src/riffsRepository/chromeStorageRiffsRepository.ts
+++ b/src/riffsRepository/chromeStorageRiffsRepository.ts
@@ -25,4 +25,16 @@ export class ChromeStorageRiffsRepository implements RiffsRepositroy {
         const result = await chrome.storage.local.get(key);
         return result[key] ?? [];
     }
+
+    async upsertRiff(videoId: string, riff: Riff): Promise<void> {
+        const key = this.storageKey(videoId);
+        const riffs = await this.getRiffs(videoId);
+        const index = riffs.findIndex((r) => r.hotkey === riff.hotkey);
+        if (index >= 0) {
+            riffs[index] = riff;
+        } else {
+            riffs.push(riff);
+        }
+        await chrome.storage.local.set({ [key]: riffs });
+    }
 }

--- a/src/riffsRepository/riffsRepository.ts
+++ b/src/riffsRepository/riffsRepository.ts
@@ -1,7 +1,8 @@
 import { Riff } from "../types";
 
 export interface RiffsRepositroy {
-    addRiff(song: string, riff: Riff): Promise<void>;
-    deleteRiff(song: string, riff: Riff): Promise<void>;
-    getRiffs(song: string): Promise<Riff[]>;
+    addRiff(videoId: string, riff: Riff): Promise<void>;
+    deleteRiff(videoId: string, riff: Riff): Promise<void>;
+    getRiffs(videoId: string): Promise<Riff[]>;
+    upsertRiff(videoId: string, riff: Riff): Promise<void>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,6 +583,14 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/chrome@^0.0.114":
+  version "0.0.114"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.114.tgz#8ceb33fa261f4b9e307fa7344ba8182d8d410d4e"
+  integrity sha512-i7qRr74IrxHtbnrZSKUuP5Uvd5EOKwlwJq/yp7+yTPihOXnPhNQO4Z5bqb1XTnrjdbUKEJicaVVbhcgtRijmLA==
+  dependencies:
+    "@types/filesystem" "*"
+    "@types/har-format" "*"
+
 "@types/chrome@^0.0.306":
   version "0.0.306"
   resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.306.tgz#67523831656fb46ce0f9e27c0ece3c911c2ff2d7"
@@ -2017,6 +2025,13 @@ jest-changed-files@^29.7.0:
     execa "^5.0.0"
     jest-util "^29.7.0"
     p-limit "^3.1.0"
+
+jest-chrome@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/jest-chrome/-/jest-chrome-0.8.0.tgz#f741f5cf49292326eb9a2507111b9a77a01a495d"
+  integrity sha512-39RR1GT9nI4e4jsuH1vIf4l5ApxxkcstjGJr+GsOURL8f4Db0UlbRnsZaM+ZRniaGtokqklUH5VFKGZZ6YztUg==
+  dependencies:
+    "@types/chrome" "^0.0.114"
 
 jest-circus@^29.7.0:
   version "29.7.0"


### PR DESCRIPTION
This does not work as intended. For the update part of the up-sert to work we need an non editable primary key. My design uses the hotkey as a riff's primary key which is editable. I'm going to merge it any ways and fix it in another PR.